### PR TITLE
Incorporate feedback from Discord; Delete potential merge() slowdown

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,10 @@ title: Home
 
 <p align="center">[<a href="https://hf.co/spaces/liujch1998/infini-gram">Web Interface</a>] [<a href="/api_doc">API Endpoint</a>] [<a href="/pkg_doc">Python Package</a>] [<a href="https://infini-gram.readthedocs.io">Docs</a>] [<a href="https://github.com/liujch1998/infini-gram">Code</a>] [<a href="https://arxiv.org/pdf/2401.17377.pdf">Paper</a>]</p>
 
+**[✨NEW]** Check out [**infini-gram mini**](https://infini-gram-mini.io/), a more storage-efficient index based on FM-index, with similar functionalities as infini-gram.
+
+**[✨NEW]** Check out [**OLMoTrace**](https://allenai.org/blog/olmotrace), an LLM behavior tracing tool we developed on top of infini-gram.
+
 <p>Join our <a href="https://discord.gg/wAhjwbjECW">Discord server</a>! Get the latest updates & maintenance announcements, ask the developer anything about infini-gram, and connect with other fellow users.</p>
 
 ---

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -587,6 +587,8 @@ Then, you can use the ``get_doc_by_rank`` query to retrieve a matching document 
    * - ``query_type``
      - see overview
      - ``get_doc_by_rank``
+   * - ``query`` or ``query_ids``
+     - The same search query as in ``find``
    * - ``s``
      - The shard index
      - An integer in range [0, ``len(segment_by_shard)``)
@@ -727,6 +729,8 @@ Then, you can use the ``get_doc_by_ptr`` query to retrieve a matching document b
    * - ``query_type``
      - see overview
      - ``get_doc_by_ptr``
+   * - ``query`` or ``query_ids``
+     - The same search query as in ``find_cnf``
    * - ``s``
      - The shard index
      - An integer in range [0, ``len(ptrs_by_shard)``)

--- a/pkg/infini_gram/indexing.py
+++ b/pkg/infini_gram/indexing.py
@@ -137,6 +137,11 @@ def tokenize(args):
                 ug_fout.write(f'{token_id} {count}\n')
             ug_fout.close()
 
+    for ds_path in ds_paths:
+        if os.path.getsize(ds_path) == 0:
+            print(f'{ds_path} is empty. Please make sure the documents exist!', flush=True)
+            exit(1)
+
 def build_sa(args):
 
     ds_paths = [os.path.join(args.save_dir, f'tokenized.{i}') for i in range(args.worker_id, args.shards, args.workers)]
@@ -160,6 +165,9 @@ def build_sa(args):
         start_time = time.time()
 
         ds_size = os.path.getsize(ds_path)
+        if ds_size < args.cpus * args.token_width + HACK:
+            print(f'{ds_path} is too small to parallelize. Please use fewer CPUs!', flush=True)
+            exit(1)
         ratio = int(np.ceil(np.log2(ds_size) / 8))
         mem_bytes = args.mem * 1024**3
         num_job_batches = 1

--- a/pkg/src/main.rs
+++ b/pkg/src/main.rs
@@ -411,9 +411,9 @@ fn cmd_merge(fpath: &String, parts_dir: &String, merged_dir: &String, num_thread
             }
         }
 
-        // Our algorithm is not linear time if there are really long duplicates
-        // found in the merge process. If this happens we'll warn once.
-        let mut did_warn_long_sequences = false;
+        // // Our algorithm is not linear time if there are really long duplicates
+        // // found in the merge process. If this happens we'll warn once.
+        // let mut did_warn_long_sequences = false;
 
         let mut prev = &texts[0][0..];
         while let Some(MergeState {suffix: _suffix, position, table_index, hacksize}) = heap.pop() {
@@ -424,22 +424,22 @@ fn cmd_merge(fpath: &String, parts_dir: &String, merged_dir: &String, num_thread
 
             if idxs[table_index] <= ends[table_index] as u64 {
                 assert!(position != u64::MAX);
-                let next = &texts[table_index][position as usize..];
+                // let next = &texts[table_index][position as usize..];
 
-                let match_len = (0..(hacksize+1)).find(|&j| !(j < next.len() && j < prev.len() && next[j] == prev[j]));
-                if !did_warn_long_sequences {
-                    if let Some(match_len_) = match_len {
-                        if match_len_ >= hacksize {
-                            println!("There is a match longer than {} bytes.", hacksize);
-                            println!("You probably don't want to be using this code on this dataset---it's (possibly) quadratic runtime now.");
-                            did_warn_long_sequences = true;
-                        }
-                    } else {
-                        println!("There is a match longer than {} bytes.", hacksize);
-                        println!("You probably don't want to be using this code on this dataset---it's quadratic runtime now.");
-                        did_warn_long_sequences = true;
-                    }
-                }
+                // let match_len = (0..(hacksize+1)).find(|&j| !(j < next.len() && j < prev.len() && next[j] == prev[j]));
+                // if !did_warn_long_sequences {
+                //     if let Some(match_len_) = match_len {
+                //         if match_len_ >= hacksize {
+                //             println!("There is a match longer than {} bytes.", hacksize);
+                //             println!("You probably don't want to be using this code on this dataset---it's (possibly) quadratic runtime now.");
+                //             did_warn_long_sequences = true;
+                //         }
+                //     } else {
+                //         println!("There is a match longer than {} bytes.", hacksize);
+                //         println!("You probably don't want to be using this code on this dataset---it's quadratic runtime now.");
+                //         did_warn_long_sequences = true;
+                //     }
+                // }
 
                 heap.push(MergeState {
                     suffix: &texts[table_index][position as usize..],
@@ -447,7 +447,7 @@ fn cmd_merge(fpath: &String, parts_dir: &String, merged_dir: &String, num_thread
                     table_index: table_index,
                     hacksize: hacksize
                 });
-                prev = next;
+                // prev = next;
             }
         }
     }


### PR DESCRIPTION
Acting on several feedback from Discord server:
* Fix bug on small dataset indexing
* Indexing: warn if the tokenized file is empty
* Documentation: get_doc_by_ptr also needs to pass in query_ids/query

Also deleted some Rust code that might be slowing down `merge()`. Tho it doesn't seem to help much.